### PR TITLE
Changing readme to reflect capitalization issue on Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
     script:
     - npm run lint
     - do-some-other-tests
-  - stage: visual-difference-tests
+  - stage: Visual-difference-tests
     script:
     - |
       if [ $TRAVIS_SECURE_ENV_VARS == true ]; then


### PR DESCRIPTION
We were having an issue where the visual difference tests were not running if the stage name was not capitalized.