### PR TITLE
Use npm ci instead of npm i

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@ async function regenGoldens (context, branchName) {
       config: {
         merge_mode: 'merge',
         install: [
-          'npm install'
+          'npm ci'
         ],
         jobs: {
           include: [{


### PR DESCRIPTION
For more reproducible golden runs.

We ran into an issue where the goldens could not be regenerated properly because it was pulling in new changes via `npm i` (vs `npm ci` which builds off of package-lock). I think building off of package-lock makes more sense