### PR TITLE
Revert "Use npm ci instead of npm i"

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@ async function regenGoldens (context, branchName) {
       config: {
         merge_mode: 'merge',
         install: [
-          'npm ci'
+          'npm install'
         ],
         jobs: {
           include: [{


### PR DESCRIPTION
Reverts BrightspaceUI/visual-difference-bot#9

I think the original change won't work if the repo is missing package-lock.json